### PR TITLE
Feat/support for languages that have no document symbol

### DIFF
--- a/src/util/symbol.ts
+++ b/src/util/symbol.ts
@@ -1,5 +1,4 @@
-import { SymbolInformation } from 'coc.nvim';
-import { SymbolKind, DocumentSymbol, Range } from 'vscode-languageserver-protocol';
+import { SymbolKind, DocumentSymbol, Range, SymbolInformation } from 'vscode-languageserver-protocol';
 import { comparePosition } from './pos';
 
 export interface SymbolInfo {


### PR DESCRIPTION
I found some languages like css / scss / less can not show the symbols. I think it is because coc-symbol-line does not have a handler for the languages which have no `documentSymbol` while `CocList outline` does.

For it, I add the handler referenced from coc.nvim and it seems work well.

![2022-06-16_15-36](https://user-images.githubusercontent.com/26080416/174017820-39e68c7a-8558-44ab-9541-305c63c14673.png)

