### PR TITLE
fix: avoid using object.hasOwnProperty

### DIFF
--- a/src/util/symbol.ts
+++ b/src/util/symbol.ts
@@ -73,7 +73,7 @@ export function getSymbolKind(kind: SymbolKind): string {
 }
 
 export function isSymbols(symbols: DocumentSymbol[] | SymbolInformation[]): symbols is DocumentSymbol[] {
-  return !symbols[0].hasOwnProperty('location');
+  return !Object.prototype.hasOwnProperty.call(symbols[0], 'location');
 }
 
 export function convertSymbols(symbols: DocumentSymbol[] | SymbolInformation[]): SymbolInfo[] {


### PR DESCRIPTION
https://github.com/neoclide/coc.nvim/issues/4244

https://github.com/neoclide/coc.nvim/commit/8f0041f53a01a5b5e15d1438c6da803421cc0d4a

https://stackoverflow.com/questions/12017693/why-use-object-prototype-hasownproperty-callmyobj-prop-instead-of-myobj-hasow